### PR TITLE
fix: align hoop_connections owner naming with postgres-management pattern

### DIFF
--- a/hoop.tf
+++ b/hoop.tf
@@ -17,8 +17,8 @@ output "hoop_connections" {
   value = local.hoop_enabled ? merge(
     {
       for key, db in var.databases :
-      "${local.psql.server_name}-${try(var.databases[key].create, true) ? mysql_database.this[key].name : var.databases[key].name}-ow" => {
-        name           = "${local.psql.server_name}-${try(var.databases[key].create, true) ? mysql_database.this[key].name : var.databases[key].name}-ow"
+      "${local.psql.server_name}-${local.normalized_owner_list[key]}" => {
+        name           = "${local.psql.server_name}-${local.normalized_owner_list[key]}"
         agent_id       = var.hoop.agent_id
         type           = "database"
         subtype        = "mysql"

--- a/secretsmanager-owners.tf
+++ b/secretsmanager-owners.tf
@@ -8,13 +8,16 @@
 #
 
 locals {
+  normalized_owner_list = {
+    for key, db in var.databases : key => replace(local.owner_list[key], "_", "-")
+  }
   owner_name_list = {
     for key, db in var.databases : key => format("%s/%s/%s/%s/%s-rds-credentials",
       local.secret_store_path,
       local.psql.engine,
       local.psql.server_name,
       replace(db.name, "_", "-"),
-      replace(local.owner_list[key], "_", "-")
+      local.normalized_owner_list[key]
     )
     if try(db.create_owner, false)
   }


### PR DESCRIPTION
## Summary

- Add `normalized_owner_list` local to `secretsmanager-owners.tf`, mirroring the established pattern in `terraform-module-aws-postgres-management`
- Replace the inline db name expression in `hoop.tf` owner for-loop (`mysql_database.this[key].name / var.databases[key].name + -ow`) with `local.normalized_owner_list[key]`
- `owner_name_list` now reuses `normalized_owner_list` instead of re-computing `replace()` inline
- Owner connection names now consistently normalize underscores to hyphens, matching the postgres-management architecture

+semver: fix