### PR TITLE
fix: export user Hoop access control

### DIFF
--- a/hoop.tf
+++ b/hoop.tf
@@ -39,14 +39,17 @@ output "hoop_connections" {
     {
       for key, role_user in var.users :
       "${local.psql.server_name}-${try(role_user.db_ref, "") != "" ? (try(var.databases[role_user.db_ref].create, true) ? mysql_database.this[role_user.db_ref].name : var.databases[role_user.db_ref].name) : role_user.database_name}-${role_user.name}" => {
-        name           = "${local.psql.server_name}-${try(role_user.db_ref, "") != "" ? (try(var.databases[role_user.db_ref].create, true) ? mysql_database.this[role_user.db_ref].name : var.databases[role_user.db_ref].name) : role_user.database_name}-${role_user.name}"
-        agent_id       = var.hoop.agent_id
-        type           = "database"
-        subtype        = "mysql"
-        tags           = try(var.hoop.tags, {})
-        access_control = toset(try(var.hoop.access_control, []))
-        access_modes   = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
-        import         = try(var.hoop.import, false)
+        name     = "${local.psql.server_name}-${try(role_user.db_ref, "") != "" ? (try(var.databases[role_user.db_ref].create, true) ? mysql_database.this[role_user.db_ref].name : var.databases[role_user.db_ref].name) : role_user.database_name}-${role_user.name}"
+        agent_id = var.hoop.agent_id
+        type     = "database"
+        subtype  = "mysql"
+        tags     = try(var.hoop.tags, {})
+        access_control = setunion(
+          toset(try(var.hoop.access_control, [])),
+          toset(try(role_user.hoop.access_control, []))
+        )
+        access_modes = { connect = "enabled", exec = "enabled", runbooks = "enabled", schema = "enabled" }
+        import       = try(var.hoop.import, false)
         secrets = {
           "envvar:HOST" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${aws_secretsmanager_secret.user[key].name}${local.hoop_secret_sep}host"
           "envvar:PORT" = "${local.hoop_secret_prefix}${local.hoop_secret_sep}${aws_secretsmanager_secret.user[key].name}${local.hoop_secret_sep}port"

--- a/variables-mysql.tf
+++ b/variables-mysql.tf
@@ -17,6 +17,8 @@
 #     host: "%"                  # (Optional) The source host for the user. Defaults to "%".
 #     tls_option: "NONE"         # (Optional) The TLS option for the user. Defaults to "NONE".
 #     import: false              # (Optional) Whether to import the user if it already exists. Defaults to false.
+#     hoop:                          # (Optional) Hoop settings for the user.
+#       access_control: ["group"]   # (Optional) Access control groups merged with hoop.access_control. Defaults to [].
 variable "users" {
   description = "Users and user attributes - see docs for example"
   type        = any


### PR DESCRIPTION
## Summary

- Merge per-user   \ into exported Hoop user connections
- Document   \ inline for module inputs
- Align AWS and Azure management modules with existing provider behavior

+semver: fix
